### PR TITLE
v0.5.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "lazrs-python" %}
-{% set version = "0.5.0" %}
+{% set version = "0.5.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/lazrs/lazrs-{{ version }}.tar.gz
-  sha256: 793359e94eb436b34877b4305570774f9b1bba34c4671238512b80b60456d9ce
+  sha256: 70880bea1c08b106c6ff46076a4eb299c2335100d5de73ef39777686932a849b
 
 build:
   number: 0
@@ -26,8 +26,8 @@ requirements:
     - maturin                # [win]
     - python                 # [win]
   host:
-    - cargo-bundle-licenses
-    - maturin 0.14.17
+    - cargo-bundle-licenses 0.5.0
+    - maturin 1.3.1
     - python
     - pip
     - wheel


### PR DESCRIPTION
lazrs-python v0.5.2

**Destination channel:** defaults

### Links

- [PKG-6203](https://anaconda.atlassian.net/browse/PKG-6203)
- [Upstream](https://github.com/laz-rs/laz-rs-python/tree/0.5.2)
- [Release notes](https://github.com/laz-rs/laz-rs-python/releases/tag/0.5.2)
- [pyproject.toml](https://github.com/laz-rs/laz-rs-python/blob/0.5.2/pyproject.toml)
 
### Explanation of changes:
  - Bump build number and build with rust 1.82
  - Built latest 0.5.* variant (that was released) in order to satisfy a few `- lazrs-python >=0.5.0,<0.6.0` pinnings I found
  - The latest version v6 supports python 3.13 and could be built after this. 

Rust < 1.81 was affected by CVE-2024-43402.

[PKG-6203]: https://anaconda.atlassian.net/browse/PKG-6203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ